### PR TITLE
Verify the host for SSL

### DIFF
--- a/src/Synology/AbstractApi.php
+++ b/src/Synology/AbstractApi.php
@@ -156,7 +156,7 @@ abstract class AbstractApi
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, self::CONNECT_TIMEOUT);
 
         // Verify SSL or not
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $this->_verifySSL);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $this->_verifySSL ? 2 : 0);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->_verifySSL);
 
         // grab URL and pass it to the browser


### PR DESCRIPTION
When the **_verifySSL** property of the **AbstractApi** class is set to **true** then I receive the following error when I do request to API:
> Notice: curl_setopt(): CURLOPT_SSL_VERIFYHOST no longer accepts the value 1, value 2 will be used instead in Synology\AbstractApi->_request() (line 159 of vendor/chmez/synology-api/src/Synology/AbstractApi.php).